### PR TITLE
[BE/API] Kafka 브로커에서 Consume 후 메시지를 SSE 로 전송한다.

### DIFF
--- a/backend/api-server/src/main/java/com/wizard/api_server/common/event/VideoCommentaryEvent.java
+++ b/backend/api-server/src/main/java/com/wizard/api_server/common/event/VideoCommentaryEvent.java
@@ -1,0 +1,19 @@
+package com.wizard.api_server.common.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class VideoCommentaryEvent extends ApplicationEvent {
+
+    private final String requestId;
+    private final String content;
+    private final long startTime;
+
+    public VideoCommentaryEvent(Object source, String requestId, String content, long startTime) {
+        super(source);
+        this.requestId = requestId;
+        this.content = content;
+        this.startTime = startTime;
+    }
+}

--- a/backend/api-server/src/main/java/com/wizard/api_server/external/kafka/video/VideoCommentaryConsumer.java
+++ b/backend/api-server/src/main/java/com/wizard/api_server/external/kafka/video/VideoCommentaryConsumer.java
@@ -1,13 +1,17 @@
 package com.wizard.api_server.external.kafka.video;
 
+import com.wizard.api_server.common.event.VideoCommentaryEvent;
 import com.wizard.api_server.external.kafka.video.dto.VideoCommentary;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class VideoCommentaryConsumer {
+
+    private final ApplicationEventPublisher eventPublisher;
 
     @KafkaListener(
             topics = "llm-commentary-events",
@@ -19,5 +23,13 @@ public class VideoCommentaryConsumer {
         System.out.println("Request ID: " + videoSummary.requestId());
         System.out.println("Timestamp: " + videoSummary.startTime());
         System.out.println("Content: " + videoSummary.content());
+
+        VideoCommentaryEvent event = new VideoCommentaryEvent(
+                this,
+                videoSummary.requestId(),
+                videoSummary.content(),
+                videoSummary.startTime()
+        );
+        eventPublisher.publishEvent(event);
     }
 }

--- a/backend/api-server/src/main/java/com/wizard/api_server/web/sse/SseEmitters.java
+++ b/backend/api-server/src/main/java/com/wizard/api_server/web/sse/SseEmitters.java
@@ -14,7 +14,7 @@ public class SseEmitters {
 
     public void addEmiter(String connectId, SseEmitter emitter) {
         emitters.put(connectId, emitter);
-        log.info("Added emitter {}", connectId);;
+        log.info("Added emitter {}", connectId);
         log.info("emitter list size: {}", emitters.size());
 
         emitter.onCompletion(() -> {
@@ -29,8 +29,28 @@ public class SseEmitters {
     }
 
     public void sendConnectEvent(SseEmitter emitter) throws IOException {
-            var event = SseEmitter.event()
-                    .name("connect");
+        var event = SseEmitter.event()
+                    .name("connect")
+                            .data("send connect event");
             emitter.send(event);
+        log.info("emitter sent first event");
     }
+
+    public void sendEvent(String requestId, String data) throws IOException {
+        SseEmitter emitter = emitters.get(requestId);
+        if (emitter != null) {
+            var event = SseEmitter.event()
+                    .name("commentary")
+                    .data(data);
+
+            emitter.send(event);
+            log.info("emitter sent comment event");
+        } else {
+            log.warn("emitter not found");
+        }
+    }
+
+    /**
+     *   {"requestId": "3ddfd9be-3896-41d3-a8d1-97e1e33c623f", "startTime": 0, "content": "# This is a commentary about the video."}
+     */
 }

--- a/backend/api-server/src/main/java/com/wizard/api_server/web/sse/VideoCommentaryEventListener.java
+++ b/backend/api-server/src/main/java/com/wizard/api_server/web/sse/VideoCommentaryEventListener.java
@@ -1,0 +1,34 @@
+package com.wizard.api_server.web.sse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wizard.api_server.common.event.VideoCommentaryEvent;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VideoCommentaryEventListener {
+    private final ObjectMapper objectMapper;
+    private final SseEmitters sseEmitters;
+
+    @EventListener
+    public void handleVideoCommentaryEvent(VideoCommentaryEvent event) {
+        try {
+            log.info("Received video commentary event: {}", objectMapper.writeValueAsString(event));
+            Map<String, Object> eventData = new HashMap<>();
+            eventData.put("startTime", event.getStartTime());
+            eventData.put("content", event.getContent());
+            String jsonData = objectMapper.writeValueAsString(eventData);
+            sseEmitters.sendEvent(event.getRequestId(),jsonData);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈 번호

<!-- 
- 관련된 이슈 번호를 `Close #` 뒤에 작성해주세요.
    - 예: `Close #12` 
-->

- Close #20 

## 📝 추가 설명

Kafka CLI 로 llm-server 에서 produce한 상황을 가정하고 프론트엔드에서 잘 받는지 확인

<!-- 
작업 내용에 대한 추가 설명이 필요한 경우 작성해주세요.
-->

### produce
![image](https://github.com/user-attachments/assets/4604dd56-b693-4695-8486-aabf1bbc271d)

### SpringEvent -> SSE sent
![image](https://github.com/user-attachments/assets/f35c4a58-59a4-44a5-a340-19dd0387ab2f)

### Frontend browser console (Network tab)
![image](https://github.com/user-attachments/assets/a6f9b74c-ee74-465b-9882-88f8dea3a7ea)
